### PR TITLE
Refactor tests and rename resources

### DIFF
--- a/src/main/java/org/acme/WelcomeResource.java
+++ b/src/main/java/org/acme/WelcomeResource.java
@@ -6,7 +6,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
 @Path("/")
-public class GreetingResource {
+public class WelcomeResource {
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)

--- a/src/test/java/org/acme/GreetingResourceIT.java
+++ b/src/test/java/org/acme/GreetingResourceIT.java
@@ -1,8 +1,0 @@
-package org.acme;
-
-import io.quarkus.test.junit.QuarkusIntegrationTest;
-
-@QuarkusIntegrationTest
-class GreetingResourceIT extends GreetingResourceTest {
-    // Execute the same tests but in packaged mode.
-}

--- a/src/test/java/org/acme/WelcomeResourceTest.java
+++ b/src/test/java/org/acme/WelcomeResourceTest.java
@@ -7,14 +7,14 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusTest
-class GreetingResourceTest {
+class WelcomeResourceTest {
     @Test
-    void testHelloEndpoint() {
+    void testRootEndpoint() {
         given()
-          .when().get("/hello")
+          .when().get("/")
           .then()
              .statusCode(200)
-             .body(is("Hello from Quarkus REST"));
+             .body(is("This a Quarkus application running in K3S to test CI/CD pipeline"));
     }
 
 }


### PR DESCRIPTION
Deleted the unnecessary GreetingResourceIT.java file, and the GreetingResourceTest.java and GreetingResource.java files were renamed to WelcomeResourceTest.java and WelcomeResource.java respectively. The tests and the endpoint were also adjusted to reflect these changes. The refactoring efforts essentially aimed to make code and test names more meaningful and easier to understand.