### PR TITLE
Refine MockMapService and modify scheduled task frequency

### DIFF
--- a/src/main/java/org/acme/SseEventSinkResource.java
+++ b/src/main/java/org/acme/SseEventSinkResource.java
@@ -92,7 +92,7 @@ public class SseEventSinkResource {
         return Response.ok(response).build();
     }
 
-    @Scheduled(every = "60s")
+    @Scheduled(every = "120s")
     void removeClosedConnections() {
         Log.info("removeClosedConnections");
         mapService.clean();

--- a/src/main/java/org/acme/services/MockMapService.java
+++ b/src/main/java/org/acme/services/MockMapService.java
@@ -13,7 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @DefaultBean
 public class MockMapService implements IMapService {
 
-    private final Map<String, SseEventSink> map =new ConcurrentHashMap<>();
+    private final Map<String, SseEventSink> map = new ConcurrentHashMap<>();
 
     @Override
     public void put(String key, SseEventSink sseEventSink) {
@@ -21,13 +21,15 @@ public class MockMapService implements IMapService {
     }
 
     @Override
-    public SseEventSink get(String key){
+    public SseEventSink get(String key) {
         return map.get(key);
     }
 
     @Override
-    public void clean(){
-        map.entrySet().removeIf(entry -> entry.getValue().isClosed());
+    public void clean() {
+        if (!map.isEmpty()) {
+            map.entrySet().removeIf(entry -> entry.getValue().isClosed());
+        }
     }
 
 


### PR DESCRIPTION
Adjustments have been made to the MockMapService class to ensure coherent formatting and to improve the 'clean' method, where a check is now in place to verify if the map is not empty before attempting to clean it. The frequency of scheduled task in SseEventSinkResource has been updated to run every 120 seconds instead of every 60 seconds.