### PR TITLE
Remove redundant newline in index.html

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -12,7 +12,6 @@
 <script>
     const eventSource = new EventSource("{endpoint}");
     eventSource.onmessage = function(event) {
-
         document.getElementById("current-date").textContent = event.data;
     };
 </script>


### PR DESCRIPTION
A redundant newline was present in the JavaScript section of index.html. This change enhances code readability by reducing unnecessary whitespace. The functionality of the event handling remains unaffected.