### PR TITLE
Add support for linux/amd64 platform in Docker build

### DIFF
--- a/.github/workflows/push-main.yaml
+++ b/.github/workflows/push-main.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           context: .
           file: src/main/docker/Dockerfile.jvm
-          platforms: linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ github.repository_owner }}/quarkus-kubernetes:v${{ steps.date_generator.outputs.date }},${{ github.repository_owner }}/quarkus-kubernetes:latest
 


### PR DESCRIPTION
Updated the GitHub Actions workflow to include linux/amd64 alongside linux/arm64 when building the Docker image. This ensures compatibility with both architecture types, broadening deployment options.