### PR TITLE
Make `ticks` a final variable in SseResource

### DIFF
--- a/src/main/java/org/acme/SseResource.java
+++ b/src/main/java/org/acme/SseResource.java
@@ -20,7 +20,7 @@ public class SseResource {
     @Inject
     Template index;
 
-    private Multi<String> ticks = Multi.createFrom().ticks().every(Duration.ofSeconds(1))
+    final private Multi<String> ticks = Multi.createFrom().ticks().every(Duration.ofSeconds(1))
             .onItem().transform(tick -> LocalDateTime.now().toString())
             .onSubscription().invoke(sub -> Log.info(sub.toString()))
             .onCancellation().invoke(() -> Log.info("No more ticks"))
@@ -39,9 +39,7 @@ public class SseResource {
     @RestStreamElementType(MediaType.TEXT_PLAIN)
     public Multi<String> see() {
         Log.info("New subscriber");
-        return ticks.onCancellation().invoke(() -> {
-            Log.info("Removing subscriber");
-        });
+        return ticks.onCancellation().invoke(() -> Log.info("Removing subscriber"));
     }
 
 


### PR DESCRIPTION
Marking `ticks` as final ensures immutability and thread safety. This change aligns with best practices and prevents accidental reassignment of the variable.