### PR TITLE
Add OpenTelemetry support and new TraceResource endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,15 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-logging</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/org/acme/TraceResource.java
+++ b/src/main/java/org/acme/TraceResource.java
@@ -1,0 +1,23 @@
+package org.acme;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.jboss.logging.Logger;
+
+@Path("/trace")
+public class TraceResource {
+
+
+    private static final Logger LOG = Logger.getLogger(TraceResource.class);
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        LOG.info("hello");
+        return "hello";
+    }
+
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
-# Incoming configuration
+quarkus.otel.logs.enabled=true
+quarkus.application.name=quarkus-sse
+quarkus.otel.exporter.otlp.logs.endpoint=http://lgtm:4317
+quarkus.otel.logs.exporter=logging

--- a/src/test/java/org/acme/TraceResourceTest.java
+++ b/src/test/java/org/acme/TraceResourceTest.java
@@ -1,0 +1,19 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+
+@QuarkusTest
+class TraceResourceTest {
+    @Test
+    void testRootEndpoint() {
+        given()
+          .when().get("/trace")
+          .then()
+             .statusCode(200);
+
+    }
+
+}


### PR DESCRIPTION
Integrated OpenTelemetry dependencies and configurations for logging export. Introduced a new `/trace` REST endpoint with basic functionality and a corresponding test to ensure endpoint availability.