### PR TITLE
Update OTLP logs endpoint and protocol configuration

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 quarkus.otel.logs.enabled=true
 quarkus.application.name=quarkus-sse
-quarkus.otel.exporter.otlp.logs.endpoint=http://lgtm:4317
+quarkus.otel.exporter.otlp.logs.endpoint=http://lgtm.default.svc.cluster.local:4318
+quarkus.otel.exporter.otlp.logs.protocol="http/protobuf"
 quarkus.otel.logs.exporter=logging


### PR DESCRIPTION
Changed the OTLP logs endpoint to use a fully qualified domain name and updated the port. Additionally, set the protocol to "http/protobuf" for compatibility with the exporter.