### PR TITLE
Update OpenTelemetry endpoint configuration

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 quarkus.otel.logs.enabled=true
 quarkus.application.name=quarkus-sse
-quarkus.otel.exporter.otlp.logs.endpoint=http://lgtm.default.svc.cluster.local:4318
-quarkus.otel.exporter.otlp.logs.protocol="http/protobuf"
+quarkus.otel.exporter.otlp.endpoint=http://lgtm:4317
+#quarkus.otel.exporter.otlp.logs.endpoint=http://lgtm.default.svc.cluster.local:4318
+#quarkus.otel.exporter.otlp.logs.protocol="http/protobuf"
 quarkus.otel.logs.exporter=logging


### PR DESCRIPTION
Replaced the OTLP logs-specific endpoint and protocol settings with a generalized OTLP endpoint. Commented out the old logs-specific configurations for potential future reference.