### PR TITLE
Enable default OTLP endpoint for log exporting.

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 quarkus.otel.logs.enabled=true
 quarkus.application.name=quarkus-sse
 quarkus.otel.exporter.otlp.endpoint=http://lgtm:4317
-#quarkus.otel.exporter.otlp.logs.endpoint=http://lgtm.default.svc.cluster.local:4318
-#quarkus.otel.exporter.otlp.logs.protocol="http/protobuf"
-quarkus.otel.logs.exporter=logging
+
+#quarkus.otel.logs.exporter=logging


### PR DESCRIPTION
Removed commented-out configuration for a custom OTLP logs endpoint and protocol. Cleaned up properties to rely on the default setup for log exporting.