### PR TITLE
Add tracing simulation endpoint with manual spans

### DIFF
--- a/src/main/java/org/acme/TraceResource.java
+++ b/src/main/java/org/acme/TraceResource.java
@@ -1,5 +1,8 @@
 package org.acme;
 
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -12,6 +15,11 @@ public class TraceResource {
 
     private static final Logger LOG = Logger.getLogger(TraceResource.class);
 
+
+
+    @Inject
+    Tracer tracer;
+
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() {
@@ -19,5 +27,55 @@ public class TraceResource {
         return "hello";
     }
 
+
+    @GET
+    @Path("/simulate")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String simulateComplexTrace() {
+        LOG.info("simulateComplexTrace - start");
+
+        simulateDatabaseCall();
+        simulateExternalServiceCall();
+
+        // Manual span
+        Span span = tracer.spanBuilder("custom-manual-span").startSpan();
+        try {
+            Thread.sleep(100); // simulate latency
+            LOG.info("Inside manual span");
+        } catch (InterruptedException e) {
+            span.recordException(e);
+            Thread.currentThread().interrupt();
+        } finally {
+            span.end();
+        }
+
+        return "Tracing simulation complete";
+    }
+
+    private void simulateDatabaseCall() {
+        Span dbSpan = tracer.spanBuilder("simulate-database-call").startSpan();
+        try {
+            Thread.sleep(150); // simulate DB delay
+            LOG.info("Simulated DB call");
+        } catch (InterruptedException e) {
+            dbSpan.recordException(e);
+            Thread.currentThread().interrupt();
+        } finally {
+            dbSpan.end();
+        }
+    }
+
+    private void simulateExternalServiceCall() {
+        Span serviceSpan = tracer.spanBuilder("simulate-external-service").startSpan();
+        try {
+            Thread.sleep(200); // simulate API delay
+            LOG.info("Simulated external service call");
+        } catch (InterruptedException e) {
+            serviceSpan.recordException(e);
+            Thread.currentThread().interrupt();
+        } finally {
+            serviceSpan.end();
+        }
+    }
 
 }

--- a/src/test/java/org/acme/TraceResourceTest.java
+++ b/src/test/java/org/acme/TraceResourceTest.java
@@ -16,4 +16,14 @@ class TraceResourceTest {
 
     }
 
+
+    @Test
+    void testSimulateEndpoint() {
+        given()
+                .when().get("/trace/simulate")
+                .then()
+                .statusCode(200);
+
+    }
+
 }


### PR DESCRIPTION
Introduced a new `/simulate` endpoint in `TraceResource` to demonstrate tracing with OpenTelemetry, including manual span creation and simulated latency for database and external service calls. Added a corresponding test to validate the new endpoint's functionality.