### PR TITLE
Add `/boom` endpoint to `TraceResource` with corresponding test

### DIFF
--- a/src/main/java/org/acme/TraceResource.java
+++ b/src/main/java/org/acme/TraceResource.java
@@ -27,6 +27,12 @@ public class TraceResource {
         return "hello";
     }
 
+    @GET
+    @Path("/boom")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String boom() {
+        throw new RuntimeException("Boom! This endpoint intentionally throws an exception");
+    }
 
     @GET
     @Path("/simulate")

--- a/src/test/java/org/acme/TraceResourceTest.java
+++ b/src/test/java/org/acme/TraceResourceTest.java
@@ -23,7 +23,14 @@ class TraceResourceTest {
                 .when().get("/trace/simulate")
                 .then()
                 .statusCode(200);
+    }
 
+    @Test
+    void testBoomEndpoint() {
+        given()
+                .when().get("/trace/boom")
+                .then()
+                .statusCode(500);
     }
 
 }


### PR DESCRIPTION
Implemented a new `/boom` endpoint in `TraceResource` that intentionally throws a runtime exception. Added a test case in `TraceResourceTest` to validate the endpoint's behavior, ensuring it returns a 500 status code.